### PR TITLE
Update to twig 2.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "zendframework/zend-mvc-i18n": "^1.0",
         "zendframework/zend-navigation": "^2.8",
         "zendframework/zend-server": "^2.7",
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^6.5.13",
         "squizlabs/php_codesniffer": "^3.3"
     },
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "homepage": "https://github.com/OxCom/zf3-twig",
     "require": {
         "php": ">=7.0",
-        "twig/twig": "^2.4",
+        "twig/twig": "^2.7",
         "zendframework/zend-modulemanager": "^2.7",
         "zendframework/zend-servicemanager": "^3.2",
         "zendframework/zend-mvc": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "zendframework/zend-mvc-i18n": "^1.0",
         "zendframework/zend-navigation": "^2.8",
         "zendframework/zend-server": "^2.7",
-        "phpunit/phpunit": "^6.5.13",
+        "phpunit/phpunit": "^7.0",
         "squizlabs/php_codesniffer": "^3.3"
     },
     "authors": [

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -7,13 +7,18 @@ return [
         ],
     ],
     'service_manager' => [
+        'aliases' => [
+            // For backwards compatibility.
+            \Twig_Environment::class => \Twig\Environment::class,
+            \Twig_Loader_Chain::class => \Twig\Loader\ChainLoader::class,
+        ],
         'factories' => [
             \ZendTwig\View\TwigStrategy::class => \ZendTwig\Service\TwigStrategyFactory::class,
             \ZendTwig\View\HelperPluginManager::class => \ZendTwig\Service\TwigHelperPluginManagerFactory::class,
             \ZendTwig\Renderer\TwigRenderer::class => \ZendTwig\Service\TwigRendererFactory::class,
             \ZendTwig\Resolver\TwigResolver::class => \ZendTwig\Service\TwigResolverFactory::class,
-            \Twig_Environment::class => \ZendTwig\Service\TwigEnvironmentFactory::class,
-            \Twig_Loader_Chain::class => \ZendTwig\Service\TwigLoaderFactory::class,
+            \Twig\Environment::class => \ZendTwig\Service\TwigEnvironmentFactory::class,
+            \Twig\Loader\ChainLoader::class => \ZendTwig\Service\TwigLoaderFactory::class,
             \ZendTwig\Loader\MapLoader::class => \ZendTwig\Service\TwigMapLoaderFactory::class,
             \ZendTwig\Loader\StackLoader::class => \ZendTwig\Service\TwigStackLoaderFactory::class,
         ],

--- a/src/Extension/AbstractExtension.php
+++ b/src/Extension/AbstractExtension.php
@@ -2,11 +2,10 @@
 
 namespace ZendTwig\Extension;
 
-use Twig_Extension;
 use Interop\Container\ContainerInterface;
 use ZendTwig\Renderer\TwigRenderer;
 
-abstract class AbstractExtension extends Twig_Extension
+abstract class AbstractExtension extends \Twig\Extension\AbstractExtension
 {
     /**
      * @var \ZendTwig\Renderer\TwigRenderer

--- a/src/Loader/MapLoader.php
+++ b/src/Loader/MapLoader.php
@@ -2,11 +2,11 @@
 
 namespace ZendTwig\Loader;
 
-use Twig_Error_Loader;
-use Twig_LoaderInterface;
-use Twig_Source;
+use Twig\Error\LoaderError;
+use Twig\Loader\LoaderInterface;
+use Twig\Source;
 
-class MapLoader implements Twig_LoaderInterface
+class MapLoader implements LoaderInterface
 {
     /**
      * Array of templates to filenames.
@@ -26,7 +26,7 @@ class MapLoader implements Twig_LoaderInterface
     public function add($name, $path) : MapLoader
     {
         if ($this->exists($name)) {
-            throw new Twig_Error_Loader(sprintf(
+            throw new LoaderError(sprintf(
                 'Name "%s" already exists in map',
                 $name
             ));
@@ -59,14 +59,14 @@ class MapLoader implements Twig_LoaderInterface
     public function isFresh($name, $time) : bool
     {
         if (!$this->exists($name)) {
-            throw new Twig_Error_Loader(sprintf(
+            throw new LoaderError(sprintf(
                 'Unable to find template "%s" from template map',
                 $name
             ));
         }
 
         if (!file_exists($this->map[$name])) {
-            throw new Twig_Error_Loader(sprintf(
+            throw new LoaderError(sprintf(
                 'Unable to open file "%s" from template map',
                 $this->map[$name]
             ));
@@ -80,28 +80,28 @@ class MapLoader implements Twig_LoaderInterface
      *
      * @param string $name The template logical name
      *
-     * @return Twig_Source
+     * @return Source
      *
-     * @throws Twig_Error_Loader When $name is not found
+     * @throws LoaderError When $name is not found
      */
-    public function getSourceContext($name) : Twig_Source
+    public function getSourceContext($name) : Source
     {
         if (!$this->exists($name)) {
-            throw new Twig_Error_Loader(sprintf(
+            throw new LoaderError(sprintf(
                 'Unable to find template "%s" from template map',
                 $name
             ));
         }
 
         if (!file_exists($this->map[$name])) {
-            throw new Twig_Error_Loader(sprintf(
+            throw new LoaderError(sprintf(
                 'Unable to open file "%s" from template map',
                 $this->map[$name]
             ));
         }
 
         $content = file_get_contents($this->map[$name]);
-        $source = new \Twig_Source($content, $name, $this->map[$name]);
+        $source = new Source($content, $name, $this->map[$name]);
 
         return $source;
     }

--- a/src/Loader/StackLoader.php
+++ b/src/Loader/StackLoader.php
@@ -2,7 +2,9 @@
 
 namespace ZendTwig\Loader;
 
-class StackLoader extends \Twig_Loader_Filesystem
+use Twig\Loader\FilesystemLoader;
+
+class StackLoader extends FilesystemLoader
 {
     /**
      * Default suffix to use

--- a/src/Module.php
+++ b/src/Module.php
@@ -1,6 +1,7 @@
 <?php
 namespace ZendTwig;
 
+use Twig\Environment;
 use Zend\EventManager\EventInterface;
 use Zend\ModuleManager\Feature\BootstrapListenerInterface;
 use Zend\ModuleManager\Feature\ConfigProviderInterface;
@@ -24,10 +25,10 @@ class Module implements ConfigProviderInterface, BootstrapListenerInterface
         $container = $app->getServiceManager();
 
         /**
-         * @var \Twig_Environment $env
+         * @var Environment $env
          */
         $config      = $container->get('Configuration');
-        $env         = $container->get(\Twig_Environment::class);
+        $env         = $container->get(Environment::class);
         $name        = static::MODULE_NAME;
         $options     = $envOptions = empty($config[$name]) ? [] : $config[$name];
         $extensions  = empty($options['extensions']) ? [] : $options['extensions'];

--- a/src/Renderer/TwigRenderer.php
+++ b/src/Renderer/TwigRenderer.php
@@ -2,9 +2,9 @@
 
 namespace ZendTwig\Renderer;
 
-use Twig_Environment;
-use Twig_Loader_Chain;
+use Twig\Environment;
 
+use Twig\Loader\ChainLoader;
 use Zend\View\Exception\RuntimeException;
 use Zend\View\Helper\ViewModel;
 use ZendTwig\Resolver\TwigResolver;
@@ -28,12 +28,12 @@ class TwigRenderer implements RendererInterface, TreeRendererInterface
     protected $canRenderTrees = true;
 
     /**
-     * @var Twig_Environment
+     * @var Environment
      */
     protected $environment;
 
     /**
-     * @var Twig_Loader_Chain
+     * @var ChainLoader
      */
     protected $loader;
 
@@ -69,10 +69,10 @@ class TwigRenderer implements RendererInterface, TreeRendererInterface
 
     /**
      * @param \Zend\View\View   $view
-     * @param Twig_Environment  $env
+     * @param Environment  $env
      * @param ResolverInterface $resolver
      */
-    public function __construct(View $view, Twig_Environment $env = null, ResolverInterface $resolver = null)
+    public function __construct(View $view, Environment $env = null, ResolverInterface $resolver = null)
     {
         $this->setView($view)
              ->setEnvironment($env)
@@ -279,11 +279,11 @@ class TwigRenderer implements RendererInterface, TreeRendererInterface
     }
 
     /**
-     * @return Twig_Environment
+     * @return Environment
      */
-    public function getEnvironment() : Twig_Environment
+    public function getEnvironment() : Environment
     {
-        if (!$this->environment instanceof Twig_Environment) {
+        if (!$this->environment instanceof Environment) {
             throw new InvalidArgumentException(sprintf(
                 'Twig environment must be Twig_Environment; got type "%s" instead',
                 (is_object($this->loader) ? get_class($this->loader) : gettype($this->loader))
@@ -294,7 +294,7 @@ class TwigRenderer implements RendererInterface, TreeRendererInterface
     }
 
     /**
-     * @param Twig_Environment $environment
+     * @param Environment $environment
      *
      * @return TwigRenderer
      */
@@ -306,11 +306,11 @@ class TwigRenderer implements RendererInterface, TreeRendererInterface
     }
 
     /**
-     * @return Twig_Loader_Chain
+     * @return ChainLoader
      */
-    public function getLoader() : Twig_Loader_Chain
+    public function getLoader() : ChainLoader
     {
-        if (!$this->loader instanceof Twig_Loader_Chain) {
+        if (!$this->loader instanceof ChainLoader) {
             throw new InvalidArgumentException(sprintf(
                 'Twig loader must implement Twig_Loader_Chain; got type "%s" instead',
                 (is_object($this->loader) ? get_class($this->loader) : gettype($this->loader))

--- a/src/Resolver/TwigResolver.php
+++ b/src/Resolver/TwigResolver.php
@@ -1,25 +1,25 @@
 <?php
 namespace ZendTwig\Resolver;
 
-use Twig_Environment;
+use Twig\Environment;
 
-use Twig_Template;
+use Twig\TemplateWrapper;
 use Zend\View\Resolver\ResolverInterface;
 use Zend\View\Renderer\RendererInterface as Renderer;
 
 class TwigResolver implements ResolverInterface
 {
     /**
-     * @var Twig_Environment
+     * @var Environment
      */
     protected $environment;
 
     /**
      * Constructor.
      *
-     * @param Twig_Environment $environment
+     * @param Environment $environment
      */
-    public function __construct(Twig_Environment $environment = null)
+    public function __construct(Environment $environment = null)
     {
         $this->environment = $environment;
     }
@@ -30,9 +30,9 @@ class TwigResolver implements ResolverInterface
      * @param  string        $name
      * @param  null|Renderer $renderer
      *
-     * @return Twig_Template
+     * @return TemplateWrapper
      */
-    public function resolve($name, Renderer $renderer = null) : Twig_Template
+    public function resolve($name, Renderer $renderer = null) : TemplateWrapper
     {
         return $this->environment
                     ->resolveTemplate($name);

--- a/src/Service/TwigEnvironmentFactory.php
+++ b/src/Service/TwigEnvironmentFactory.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZendTwig\Service;
 
-use Twig_Environment;
+use Twig\Environment;
 use ZendTwig\Module;
 
 use Interop\Container\ContainerInterface;
@@ -16,16 +16,16 @@ class TwigEnvironmentFactory implements FactoryInterface
      * @param string             $requestedName
      * @param array|null         $options
      *
-     * @return Twig_Environment
+     * @return Environment
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null) : Twig_Environment
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null) : Environment
     {
         $config      = $container->get('Configuration');
         $name        = Module::MODULE_NAME;
         $options     = $envOptions = empty($config[$name]) ? [] : $config[$name];
         $envOptions  = empty($options['environment']) ? [] : $options['environment'];
         $loader      = $container->get('Twig_Loader_Chain');
-        $env         = new Twig_Environment($loader, $envOptions);
+        $env         = new Environment($loader, $envOptions);
         $zendHelpers = !isset($options['invoke_zend_helpers']) ? false : (bool)$options['invoke_zend_helpers'];
 
         if ($zendHelpers) {

--- a/src/Service/TwigLoaderFactory.php
+++ b/src/Service/TwigLoaderFactory.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZendTwig\Service;
 
-use Twig_Loader_Chain;
+use Twig\Loader\ChainLoader;
 use ZendTwig\Module;
 
 use Interop\Container\ContainerInterface;
@@ -17,15 +17,15 @@ class TwigLoaderFactory implements FactoryInterface
      * @param string             $requestedName
      * @param array|null         $options
      *
-     * @return Twig_Loader_Chain
+     * @return ChainLoader
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null) : Twig_Loader_Chain
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null) : ChainLoader
     {
         $config  = $container->get('Configuration');
         $name    = Module::MODULE_NAME;
         $options = $envOptions = empty($config[$name]) ? [] : $config[$name];
         $list    = empty($options['loader_chain']) ? [] : $options['loader_chain'];
-        $chain   = new Twig_Loader_Chain();
+        $chain   = new ChainLoader();
 
         foreach ($list as $loader) {
             if (!is_string($loader) || !$container->has($loader)) {

--- a/src/Service/TwigMapLoaderFactory.php
+++ b/src/Service/TwigMapLoaderFactory.php
@@ -16,7 +16,6 @@ class TwigMapLoaderFactory implements FactoryInterface
      * @param array|null         $options
      *
      * @return MapLoader
-     * @throws \Twig_Error_Loader
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null) : MapLoader
     {

--- a/src/Service/TwigRendererFactory.php
+++ b/src/Service/TwigRendererFactory.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZendTwig\Service;
 
-use Twig_Environment;
+use Twig\Environment;
 use ZendTwig\Module;
 use ZendTwig\Renderer\TwigRenderer;
 use ZendTwig\Resolver\TwigResolver;
@@ -27,9 +27,9 @@ class TwigRendererFactory implements FactoryInterface
         $options     = empty($config[$name]) ? [] : $config[$name];
 
         /**
-         * @var Twig_Environment $env
+         * @var Environment $env
          */
-        $env      = $container->get(Twig_Environment::class);
+        $env      = $container->get(Environment::class);
         $view     = $container->get(View::class);
         $resolver = $container->get(TwigResolver::class);
         $renderer = new TwigRenderer($view, $env, $resolver);

--- a/src/Service/TwigResolverFactory.php
+++ b/src/Service/TwigResolverFactory.php
@@ -1,6 +1,7 @@
 <?php
 namespace ZendTwig\Service;
 
+use Twig\Environment;
 use ZendTwig\Resolver\TwigResolver;
 
 use Interop\Container\ContainerInterface;
@@ -17,6 +18,6 @@ class TwigResolverFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null) : TwigResolver
     {
-        return new TwigResolver($container->get('Twig_Environment'));
+        return new TwigResolver($container->get(Environment::class));
     }
 }

--- a/src/View/FallbackFunction.php
+++ b/src/View/FallbackFunction.php
@@ -2,7 +2,7 @@
 
 namespace ZendTwig\View;
 
-use Twig_Function;
+use Twig\TwigFunction;
 use ZendTwig\Extension\Extension;
 
 class FallbackFunction
@@ -10,7 +10,7 @@ class FallbackFunction
     /**
      * @param       $name
      *
-     * @return \Twig_Function
+     * @return TwigFunction
      */
     public static function build($name)
     {
@@ -44,6 +44,6 @@ class FallbackFunction
             'is_safe'           => ['all'],
         ];
 
-        return new Twig_Function($name, $callable, $options);
+        return new TwigFunction($name, $callable, $options);
     }
 }

--- a/tests/ZendTwig/ModuleTest.php
+++ b/tests/ZendTwig/ModuleTest.php
@@ -3,6 +3,7 @@
 namespace ZendTwig\Test;
 
 use PHPUnit\Framework\TestCase;
+use Twig\Environment;
 use Zend\Mvc\MvcEvent;
 use ZendTwig\Module;
 
@@ -65,9 +66,9 @@ class ModuleTest extends TestCase
         $module->onBootstrap($e);
 
         /**
-         * @var \Twig_Environment $twig
+         * @var Environment $twig
          */
-        $twig = $e->getApplication()->getServiceManager()->get('Twig_Environment');
+        $twig = $e->getApplication()->getServiceManager()->get(Environment::class);
         $ex   = $twig->getExtensions();
 
         $this->assertNotEmpty($ex['ZendTwig\Test\Fixture\Extension\DummyExtension']);

--- a/tests/ZendTwig/Renderer/TwigRendererTest.php
+++ b/tests/ZendTwig/Renderer/TwigRendererTest.php
@@ -3,7 +3,7 @@
 namespace ZendTwig\Test\Renderer;
 
 use PHPUnit\Framework\TestCase;
-use Twig_Environment;
+use Twig\Environment;
 use ZendTwig\Test\Bootstrap;
 use ZendTwig\Renderer\TwigRenderer;
 
@@ -29,7 +29,7 @@ class TwigRendererTest extends TestCase
          */
         $sm     = Bootstrap::getInstance()->getServiceManager();
         $render = $sm->get(TwigRenderer::class);
-        $env = $sm->get(Twig_Environment::class);
+        $env = $sm->get(Environment::class);
 
         $this->assertSame($env, $render->getEnvironment());
     }

--- a/tests/ZendTwig/View/FallbackFunctionTest.php
+++ b/tests/ZendTwig/View/FallbackFunctionTest.php
@@ -3,7 +3,7 @@
 namespace ZendTwig\Test\View;
 
 use PHPUnit\Framework\TestCase;
-use Twig_Environment;
+use Twig\Environment;
 use ZendTwig\Test\Bootstrap;
 use ZendTwig\View\TwigStrategy;
 
@@ -12,10 +12,10 @@ class FallbackFunctionTest extends TestCase
     public function testBindCallback()
     {
         /**
-         * @var Twig_Environment $env
+         * @var Environment $env
          */
         $sm  = Bootstrap::getInstance()->getServiceManager();
-        $env = $sm->get('Twig_Environment');
+        $env = $sm->get(Environment::class);
 
         /**
          * @var \Twig_ExtensionSet $extensionSet
@@ -36,14 +36,14 @@ class FallbackFunctionTest extends TestCase
     public function testNoCallback()
     {
         /**
-         * @var Twig_Environment $env
+         * @var Environment $env
          */
         $config = include(__DIR__ . '/../../Fixture/config/application.config.php');
         $config['module_listener_options']['config_glob_paths'] = [
             realpath(__DIR__) . '/../../Fixture/config/fallback/{{,*.}global}.php',
         ];
         $sm  = Bootstrap::getInstance($config)->getServiceManager();
-        $env = $sm->get(Twig_Environment::class);
+        $env = $sm->get(Environment::class);
 
         /**
          * @var \Twig_ExtensionSet $extensionSet


### PR DESCRIPTION
Hey.

Twig versions below 2.7 got a security issue so they will conflict with roave/security-advisories.

I updated every class to its corresponding new twig class.

Would be happy if this would not take so long to merge as we could not update our packages at the moment.

Best regards