### PR TITLE
Bump twig to v3.4.3 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "homepage": "https://github.com/OxCom/zf3-twig",
     "require": {
         "php": ">=7.0",
-        "twig/twig": "^2.12|^3.0.1",
+        "twig/twig": "^2.12|^3.4.3",
         "laminas/laminas-modulemanager": "^2.7",
         "laminas/laminas-servicemanager": "^3.2",
         "laminas/laminas-mvc": "^3.0",


### PR DESCRIPTION
Fix security issue

_When using the filesystem loader to load templates for which the name is a user input, it is possible to use the source or include statement to read arbitrary files from outside the templates directory when using a namespace like @somewhere/../some.file (in such a case, validation is bypassed)._

- [x] Dump Twig to v3.4.3
- [ ] Drop support for PHP version less then 7.4
- [ ] Update tests to handle latest version of twig and laminas